### PR TITLE
feat: oco3 data caching service

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -85,6 +85,7 @@ jobs:
         run: |
           yarn
           CI=false yarn build
+          node ./dataCaching.js
 
       - name: Upload build folder
         uses: actions/upload-artifact@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -84,8 +84,8 @@ jobs:
           REACT_APP_CLOUD_BROWSE_URL: ${{vars.REACT_APP_CLOUD_BROWSE_URL}}
         run: |
           yarn
-          CI=false yarn build
           node ./dataCaching.js
+          CI=false yarn build
 
       - name: Upload build folder
         uses: actions/upload-artifact@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -80,6 +80,7 @@ jobs:
         run: |
           yarn
           node ./dataCaching.js
+        continue-on-error: false
 
       - name: Building 🔧
         working-directory: ./

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -72,6 +72,15 @@ jobs:
       - name: Install Yarn
         run: npm install -g yarn
 
+      - name: Cache the OCO3 STAC items 🔧
+        working-directory: ./
+        env:
+          PUBLIC_URL: ${{ vars.PUBLIC_URL }}
+          REACT_APP_STAC_API_URL: ${{ vars.REACT_APP_STAC_API_URL }}
+        run: |
+          yarn
+          node ./dataCaching.js
+
       - name: Building 🔧
         working-directory: ./
         env:
@@ -84,7 +93,6 @@ jobs:
           REACT_APP_CLOUD_BROWSE_URL: ${{vars.REACT_APP_CLOUD_BROWSE_URL}}
         run: |
           yarn
-          node ./dataCaching.js
           CI=false yarn build
 
       - name: Upload build folder

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -84,6 +84,7 @@ jobs:
         run: |
           yarn
           node ./dataCaching.js
+        continue-on-error: false
 
       - name: Build and deploy
         working-directory: ./

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -88,8 +88,8 @@ jobs:
           REACT_APP_CLOUD_BROWSE_URL: ${{vars.REACT_APP_CLOUD_BROWSE_URL}}
         run: |
           yarn
-          CI=false yarn build
           node ./dataCaching.js
+          CI=false yarn build
           aws s3 sync build/ s3://${{ env.S3_BUCKET }}${{ vars.PUBLIC_URL }}pr-preview-${{ github.event.number }}
           COMMENT+="- 🛰️ Pr-Preview on : ${{ vars.PREVIEW_WEB_DISTRIBUTION_URL }}${{ vars.PUBLIC_URL }}pr-preview-${{ github.event.number }} \n \n"
           echo "COMMENT=${COMMENT}" >> $GITHUB_ENV

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -76,6 +76,15 @@ jobs:
           role-session-name: ${{ github.repository_owner }}
           aws-region: us-west-2
 
+      - name: Cache the OCO3 STAC items 🔧
+        working-directory: ./
+        env:
+          PUBLIC_URL: ${{ vars.PUBLIC_URL }}
+          REACT_APP_STAC_API_URL: ${{ vars.REACT_APP_STAC_API_URL }}
+        run: |
+          yarn
+          node ./dataCaching.js
+
       - name: Build and deploy
         working-directory: ./
         env:
@@ -88,7 +97,6 @@ jobs:
           REACT_APP_CLOUD_BROWSE_URL: ${{vars.REACT_APP_CLOUD_BROWSE_URL}}
         run: |
           yarn
-          node ./dataCaching.js
           CI=false yarn build
           aws s3 sync build/ s3://${{ env.S3_BUCKET }}${{ vars.PUBLIC_URL }}pr-preview-${{ github.event.number }}
           COMMENT+="- 🛰️ Pr-Preview on : ${{ vars.PREVIEW_WEB_DISTRIBUTION_URL }}${{ vars.PUBLIC_URL }}pr-preview-${{ github.event.number }} \n \n"

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -89,6 +89,7 @@ jobs:
         run: |
           yarn
           CI=false yarn build
+          node ./dataCaching.js
           aws s3 sync build/ s3://${{ env.S3_BUCKET }}${{ vars.PUBLIC_URL }}pr-preview-${{ github.event.number }}
           COMMENT+="- 🛰️ Pr-Preview on : ${{ vars.PREVIEW_WEB_DISTRIBUTION_URL }}${{ vars.PUBLIC_URL }}pr-preview-${{ github.event.number }} \n \n"
           echo "COMMENT=${COMMENT}" >> $GITHUB_ENV

--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -1,0 +1,78 @@
+name: Update data on a schedule
+
+on:
+    schedule:
+      - cron: 0 0 1 * * # Runs on the first day of every month
+    workflow_dispatch: # Can be run manually if needed
+
+jobs:
+  update-data:
+    runs-on: ubuntu-latest
+
+    permissions:
+      # Give the default GITHUB_TOKEN write permission to commit and push the
+      # added or changed files to the repository and create a pull request
+      contents: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # checks if the required env variables and secrets are present
+      - name: Validate required variables and secrets
+        run: |
+          missing_vars=()
+
+          # Check for required variables
+          # Variables for the Application: Remove unnecessary variables for the fork. 
+          [ -z "${{ vars.PUBLIC_URL }}" ] && missing_vars+=("vars.PUBLIC_URL")
+          # note: vars.PUBLIC_URL is expected to have leading and trailing /
+          [ -z "${{ vars.REACT_APP_STAC_API_URL }}" ] && missing_vars+=("vars.REACT_APP_STAC_API_URL")
+          # Variables for the Static Build placement in AWS.
+          [ -z "${{ vars.DEPLOYMENT_BUCKET }}" ] && missing_vars+=("vars.DEPLOYMENT_BUCKET")
+          [ -z "${{ vars.DEPLOYMENT_REGION }}" ] && missing_vars+=("vars.DEPLOYMENT_REGION")
+          [ -z "${{ secrets.DEPLOYMENT_ROLE_ARN }}" ] && missing_vars+=("secrets.DEPLOYMENT_ROLE_ARN")
+          [ -z "${{ secrets.CF_DISTRIBUTION_ID }}" ] && missing_vars+=("secrets.CF_DISTRIBUTION_ID")
+          # Add additional variables needed for the forked application here to validate.
+
+          # If any variables are missing, print them and exit with an error
+          if [ ${#missing_vars[@]} -ne 0 ]; then
+            echo "Error: The following required variables are missing:"
+            printf '%s\n' "${missing_vars[@]}"
+            exit 1
+          fi
+        shell: bash
+
+      - name: Read Node.js version from .nvmrc
+        id: nvm
+        run: echo "::set-output name=NODE_VERSION::$(cat .nvmrc)"
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ steps.nvm.outputs.NODE_VERSION }}
+
+      - name: Install Yarn
+        run: npm install -g yarn
+
+      - name: Update the data 🔧
+        working-directory: ./
+        env:
+          PUBLIC_URL: ${{ vars.PUBLIC_URL }}
+          REACT_APP_STAC_API_URL: ${{ vars.REACT_APP_STAC_API_URL }}
+        run: |
+          yarn
+          node ./dataCaching.js
+
+      - name: Upload to S3
+        run: |
+          aws s3 sync "./public/oco3-co2-sams-daygrid-v11r.json" s3://${{ vars.DEPLOYMENT_BUCKET }}${{ vars.PUBLIC_URL}}/oco3-co2-sams-daygrid-v11r.json --cache-control max-age=30,must-revalidate,s-maxage=604800 --delete
+
+      - name: Calculate PUBLIC URL Parent Path
+        run: echo "PUBLIC_URL_PARENT=$(dirname '${{ vars.PUBLIC_URL }}')" >> $GITHUB_ENV
+
+      - name: Request Invalidation to AWS Cloudfront
+        uses: oneyedev/aws-cloudfront-invalidation@v1
+        with:
+          distribution-id: ${{ secrets.CF_DISTRIBUTION_ID }}
+          paths: |
+            ${{ env.PUBLIC_URL_PARENT }}/*

--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -62,6 +62,7 @@ jobs:
         run: |
           yarn
           node ./dataCaching.js
+        continue-on-error: false
 
       - name: Upload to S3
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ yarn-error.log*
 yarn.lock
 package-lock.json
 dist/
+
+public/oco3-co2-sams-daygrid-v11r.json

--- a/dataCaching.js
+++ b/dataCaching.js
@@ -1,0 +1,126 @@
+// this service uses the api service to collect all the data and then create a json at the end.
+
+const dotenv = require('dotenv');
+const fs = require('fs');
+
+dotenv.config(); // Load environment variables from .env
+
+async function downloadCache(collectionId) {
+  try {
+    // get all the collection items
+    const collectionItemUrl = `${process.env.REACT_APP_STAC_API_URL}/collections/${collectionId}/items`;
+    const data = await fetchAllFromSTACAPI(collectionItemUrl);
+    console.log(":::>>>> ", data)
+    return data;
+  } catch (error) {
+    console.error('Error fetching data:', error);
+  }
+}
+
+function stacItemResponse(collectionId, features) {
+  return {
+    type: 'FeatureCollection',
+    links: [
+      {
+        rel: 'collection',
+        type: 'application/json',
+        href: `${process.env.REACT_APP_STAC_API_URL}/collections/${collectionId}`,
+      },
+      {
+        rel: 'parent',
+        type: 'application/json',
+        href: `${process.env.REACT_APP_STAC_API_URL}/collections/${collectionId}`,
+      },
+      {
+        rel: 'root',
+        type: 'application/json',
+        href: `${process.env.REACT_APP_STAC_API_URL}/`,
+      },
+      {
+        rel: 'self',
+        type: 'application/geo+json',
+        href: `https://staging.openveda.cloud/api/stac/collections/${collectionId}/items`,
+      },
+    ],
+    features: features,
+    numberMatched: features.length,
+    numberReturned: features.length,
+  };
+}
+
+(async function main() {
+  let collectionId = process.argv.slice(2)[0] || 'oco3-co2-sams-daygrid-v11r';
+  let data = await downloadCache(collectionId);
+  let stacItems = stacItemResponse(collectionId, data);
+  const jsonResponse = JSON.stringify(stacItems, null, 2);
+  if (!fs.existsSync('./public')) {
+    fs.mkdirSync('./public');
+  }
+  fs.writeFileSync(`./public/${collectionId}.json`, jsonResponse);
+})();
+
+// helpers
+
+async function fetchAllFromSTACAPI(STACApiUrl) {
+  // it will fetch all collection items from all stac api.
+  // do not provide offset and limits in the url
+  try {
+    return await apiCaller(STACApiUrl);
+  } catch (error) {
+    console.error('Error fetching data:', error);
+    return [];
+  }
+}
+
+/**
+ * Fetches data from a STAC API endpoint.
+ *
+ * @param {string} STACApiUrl The URL of the STAC API endpoint.
+ * @returns {Promise<any>} A promise that resolves to the list of items fetched from the API.
+ */
+async function apiCaller(STACApiUrl) {
+  let requiredResult = [];
+
+  if (!STACApiUrl) return requiredResult;
+
+  let urlWithLimit = STACApiUrl;
+
+  if (!STACApiUrl.includes('limit') && STACApiUrl.includes('token')) {
+    urlWithLimit = `${STACApiUrl}&limit=10000`;
+  }
+  if (!STACApiUrl.includes('limit') && !STACApiUrl.includes('token')) {
+    urlWithLimit = `${STACApiUrl}?limit=10000`;
+  }
+
+  console.log('## fetching from --> ', urlWithLimit);
+  const response = await fetch(urlWithLimit);
+  if (!response.ok) {
+    throw new Error('Error in Network');
+  }
+  const jsonResult = await response.json();
+  requiredResult.push(...getResultArray(jsonResult));
+  console.log('## fetching from --> ', urlWithLimit, ' Complete.');
+
+  let next = '';
+  jsonResult.links.forEach((link) => {
+    if (link.rel === 'next') {
+      next = link.href;
+    }
+  });
+
+  // recursive call to fetch the data
+  let subApiResult = await apiCaller(next);
+  return [...requiredResult, ...subApiResult];
+}
+
+function getResultArray(result) {
+  if ('features' in result) {
+    // the result is for collection item
+    return result.features;
+  }
+  if ('collections' in result) {
+    // the result is for collection
+    return result.collections;
+  }
+  return [];
+}

--- a/dataCaching.js
+++ b/dataCaching.js
@@ -20,6 +20,7 @@ async function downloadCache(collectionId) {
     return data;
   } catch (error) {
     console.error('Error fetching data:', error);
+    process.exit(1);
   }
 }
 
@@ -55,14 +56,19 @@ function stacItemResponse(collectionId, features) {
 }
 
 (async function main() {
-  let collectionId = process.argv.slice(2)[0] || 'oco3-co2-sams-daygrid-v11r';
-  let data = await downloadCache(collectionId);
-  let stacItems = stacItemResponse(collectionId, data);
-  const jsonResponse = JSON.stringify(stacItems, null, 2);
-  if (!fs.existsSync('./public')) {
-    fs.mkdirSync('./public');
+  try {
+    let collectionId = process.argv.slice(2)[0] || 'oco3-co2-sams-daygrid-v11r';
+    let data = await downloadCache(collectionId);
+    let stacItems = stacItemResponse(collectionId, data);
+    const jsonResponse = JSON.stringify(stacItems, null, 2);
+    if (!fs.existsSync('./public')) {
+      fs.mkdirSync('./public');
+    }
+    fs.writeFileSync(`./public/${collectionId}.json`, jsonResponse);
+  } catch (error) {
+    console.error('Error fetching data:', error);
+    process.exit(1);
   }
-  fs.writeFileSync(`./public/${collectionId}.json`, jsonResponse);
 })();
 
 // helpers

--- a/dataCaching.js
+++ b/dataCaching.js
@@ -1,4 +1,11 @@
-// this service uses the api service to collect all the data and then create a json at the end.
+// This service uses the api service to collect all the data and then create a json at the end.
+// The reason behind this service is to eager load all the application data beforehand.
+// The current implementation of STAC api doesnot allow parallelization to fetch the STAC items.
+// It is because the pagination of current STAC API implementation needs the next and limit.
+// Here, next dependent on its previous response.
+// Hence, to speed up the process of collecting the STAC items for OCO3 collection,
+// we have created this task. This runs before deployment (both preview and non-preview)
+// It is also triggered on some frequency to update the data.
 
 const dotenv = require('dotenv');
 const fs = require('fs');
@@ -10,7 +17,6 @@ async function downloadCache(collectionId) {
     // get all the collection items
     const collectionItemUrl = `${process.env.REACT_APP_STAC_API_URL}/collections/${collectionId}/items`;
     const data = await fetchAllFromSTACAPI(collectionItemUrl);
-    console.log(":::>>>> ", data)
     return data;
   } catch (error) {
     console.error('Error fetching data:', error);

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "web-vitals": "^2.1.0"
   },
   "scripts": {
-    "start": "node ./dataCaching.js && craco start",
+    "start": "if [ ! -f ./public/oco3-co2-sams-daygrid-v11r.json ]; then node ./dataCaching.js; fi && craco start",
     "build": "craco build",
     "test": "craco test",
     "eject": "react-scripts eject",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "web-vitals": "^2.1.0"
   },
   "scripts": {
-    "start": "craco start",
+    "start": "node ./dataCaching.js && craco start",
     "build": "craco build",
     "test": "craco test",
     "eject": "react-scripts eject",
@@ -79,6 +79,7 @@
   "devDependencies": {
     "@craco/craco": "^7.1.0",
     "@types/d3": "^7.4.3",
+    "dotenv": "^17.2.1",
     "eslint": "^8.56.0",
     "eslint-config-prettier": "^10.0.1",
     "eslint-plugin-prettier": "^5.2.3",

--- a/src/assets/dataset/metadata.json
+++ b/src/assets/dataset/metadata.json
@@ -594,7 +594,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_Low"
+      "target_type": "SIF_Low (Ecostress)"
     },
     {
       "target_id": "ecostress_ar_slu",
@@ -616,7 +616,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_Low"
+      "target_type": "SIF_Low (Ecostress)"
     },
     {
       "target_id": "ecostress_ar_vir",
@@ -638,7 +638,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_Low"
+      "target_type": "SIF_Low (Ecostress)"
     },
     {
       "target_id": "ecostress_au_asm",
@@ -657,7 +657,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_Low"
+      "target_type": "SIF_Low (Ecostress)"
     },
     {
       "target_id": "ecostress_au_cum",
@@ -679,7 +679,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_Low"
+      "target_type": "SIF_Low (Ecostress)"
     },
     {
       "target_id": "ecostress_au_das",
@@ -701,7 +701,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_Low"
+      "target_type": "SIF_Low (Ecostress)"
     },
     {
       "target_id": "ecostress_au_dry",
@@ -723,7 +723,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_Low"
+      "target_type": "SIF_Low (Ecostress)"
     },
     {
       "target_id": "ecostress_au_how",
@@ -745,7 +745,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_Low"
+      "target_type": "SIF_Low (Ecostress)"
     },
     {
       "target_id": "ecostress_au_lit",
@@ -767,7 +767,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_Low"
+      "target_type": "SIF_Low (Ecostress)"
     },
     {
       "target_id": "ecostress_au_stp",
@@ -789,7 +789,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_Low"
+      "target_type": "SIF_Low (Ecostress)"
     },
     {
       "target_id": "ecostress_au_tum",
@@ -811,7 +811,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_Low"
+      "target_type": "SIF_Low (Ecostress)"
     },
     {
       "target_id": "ecostress_au_wom",
@@ -833,7 +833,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_Low"
+      "target_type": "SIF_Low (Ecostress)"
     },
     {
       "target_id": "ecostress_au_ync",
@@ -855,7 +855,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_Low"
+      "target_type": "SIF_Low (Ecostress)"
     },
     {
       "target_id": "ecostress_bdog",
@@ -877,7 +877,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_Low"
+      "target_type": "SIF_Low (Ecostress)"
     },
     {
       "target_id": "ecostress_be_lon",
@@ -896,7 +896,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_Low"
+      "target_type": "SIF_Low (Ecostress)"
     },
     {
       "target_id": "ecostress_be_vie",
@@ -918,7 +918,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_Low"
+      "target_type": "SIF_Low (Ecostress)"
     },
     {
       "target_id": "ecostress_br_cmt",
@@ -940,7 +940,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_Low"
+      "target_type": "SIF_Low (Ecostress)"
     },
     {
       "target_id": "ecostress_br_no",
@@ -962,7 +962,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_Low"
+      "target_type": "SIF_Low (Ecostress)"
     },
     {
       "target_id": "ecostress_ca_pr_emss",
@@ -984,7 +984,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_Low"
+      "target_type": "SIF_Low (Ecostress)"
     },
     {
       "target_id": "ecostress_ca_tp",
@@ -1006,7 +1006,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_Low"
+      "target_type": "SIF_Low (Ecostress)"
     },
     {
       "target_id": "ecostress_ch_dav",
@@ -1028,7 +1028,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_Low"
+      "target_type": "SIF_Low (Ecostress)"
     },
     {
       "target_id": "ecostress_ch_fru",
@@ -1050,7 +1050,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_Low"
+      "target_type": "SIF_Low (Ecostress)"
     },
     {
       "target_id": "ecostress_ch_lae",
@@ -1072,7 +1072,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_Low"
+      "target_type": "SIF_Low (Ecostress)"
     },
     {
       "target_id": "ecostress_cr_fsc",
@@ -1094,7 +1094,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_Low"
+      "target_type": "SIF_Low (Ecostress)"
     },
     {
       "target_id": "ecostress_cr_srnp_emss",
@@ -1116,7 +1116,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_Low"
+      "target_type": "SIF_Low (Ecostress)"
     },
     {
       "target_id": "ecostress_cz_bk1",
@@ -1135,7 +1135,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_Low"
+      "target_type": "SIF_Low (Ecostress)"
     },
     {
       "target_id": "ecostress_de_rus",
@@ -1154,7 +1154,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_Low"
+      "target_type": "SIF_Low (Ecostress)"
     },
     {
       "target_id": "ecostress_de_tha",
@@ -1176,7 +1176,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_Low"
+      "target_type": "SIF_Low (Ecostress)"
     },
     {
       "target_id": "ecostress_efgf",
@@ -1198,7 +1198,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_Low"
+      "target_type": "SIF_Low (Ecostress)"
     },
     {
       "target_id": "ecostress_fr_fon",
@@ -1217,7 +1217,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_Low"
+      "target_type": "SIF_Low (Ecostress)"
     },
     {
       "target_id": "ecostress_il_yat",
@@ -1236,7 +1236,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_Low"
+      "target_type": "SIF_Low (Ecostress)"
     },
     {
       "target_id": "ecostress_it_cp2",
@@ -1255,7 +1255,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_Low"
+      "target_type": "SIF_Low (Ecostress)"
     },
     {
       "target_id": "ecostress_it_tor",
@@ -1274,7 +1274,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_Low"
+      "target_type": "SIF_Low (Ecostress)"
     },
     {
       "target_id": "ecostress_ke_mak",
@@ -1296,7 +1296,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_Low"
+      "target_type": "SIF_Low (Ecostress)"
     },
     {
       "target_id": "ecostress_kr_gck",
@@ -1318,7 +1318,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_Low"
+      "target_type": "SIF_Low (Ecostress)"
     },
     {
       "target_id": "ecostress_ne_waf",
@@ -1340,7 +1340,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_Low"
+      "target_type": "SIF_Low (Ecostress)"
     },
     {
       "target_id": "ecostress_npbb",
@@ -1362,7 +1362,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_Low"
+      "target_type": "SIF_Low (Ecostress)"
     },
     {
       "target_id": "ecostress_nz_bfm",
@@ -1381,7 +1381,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_Low"
+      "target_type": "SIF_Low (Ecostress)"
     },
     {
       "target_id": "ecostress_nz_kop",
@@ -1403,7 +1403,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_Low"
+      "target_type": "SIF_Low (Ecostress)"
     },
     {
       "target_id": "ecostress_nz_oxf",
@@ -1425,7 +1425,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_Low"
+      "target_type": "SIF_Low (Ecostress)"
     },
     {
       "target_id": "ecostress_nz_sco",
@@ -1444,7 +1444,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_Low"
+      "target_type": "SIF_Low (Ecostress)"
     },
     {
       "target_id": "ecostress_sleg",
@@ -1466,7 +1466,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_Low"
+      "target_type": "SIF_Low (Ecostress)"
     },
     {
       "target_id": "ecostress_ssh_czo_cal",
@@ -1488,7 +1488,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_Low"
+      "target_type": "SIF_Low (Ecostress)"
     },
     {
       "target_id": "ecostress_ssh_czo_shale",
@@ -1510,7 +1510,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_Low"
+      "target_type": "SIF_Low (Ecostress)"
     },
     {
       "target_id": "ecostress_us_arm",
@@ -1532,7 +1532,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_Low"
+      "target_type": "SIF_Low (Ecostress)"
     },
     {
       "target_id": "ecostress_us_bar",
@@ -1554,7 +1554,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_Low"
+      "target_type": "SIF_Low (Ecostress)"
     },
     {
       "target_id": "ecostress_us_bi1",
@@ -1576,7 +1576,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_Low"
+      "target_type": "SIF_Low (Ecostress)"
     },
     {
       "target_id": "ecostress_us_bsg",
@@ -1598,7 +1598,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_Low"
+      "target_type": "SIF_Low (Ecostress)"
     },
     {
       "target_id": "ecostress_us_ced",
@@ -1620,7 +1620,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_Low"
+      "target_type": "SIF_Low (Ecostress)"
     },
     {
       "target_id": "ecostress_us_cf1",
@@ -1642,7 +1642,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_Low"
+      "target_type": "SIF_Low (Ecostress)"
     },
     {
       "target_id": "ecostress_us_cs1",
@@ -1664,7 +1664,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_Low"
+      "target_type": "SIF_Low (Ecostress)"
     },
     {
       "target_id": "ecostress_us_cz1",
@@ -1683,7 +1683,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_Low"
+      "target_type": "SIF_Low (Ecostress)"
     },
     {
       "target_id": "ecostress_us_cz2",
@@ -1702,7 +1702,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_Low"
+      "target_type": "SIF_Low (Ecostress)"
     },
     {
       "target_id": "ecostress_us_hn1",
@@ -1724,7 +1724,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_Low"
+      "target_type": "SIF_Low (Ecostress)"
     },
     {
       "target_id": "ecostress_us_hn2",
@@ -1746,7 +1746,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_Low"
+      "target_type": "SIF_Low (Ecostress)"
     },
     {
       "target_id": "ecostress_us_kfs",
@@ -1768,7 +1768,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_Low"
+      "target_type": "SIF_Low (Ecostress)"
     },
     {
       "target_id": "ecostress_us_kon",
@@ -1790,7 +1790,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_Low"
+      "target_type": "SIF_Low (Ecostress)"
     },
     {
       "target_id": "ecostress_us_los",
@@ -1812,7 +1812,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_Low"
+      "target_type": "SIF_Low (Ecostress)"
     },
     {
       "target_id": "ecostress_us_me2",
@@ -1834,7 +1834,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_Low"
+      "target_type": "SIF_Low (Ecostress)"
     },
     {
       "target_id": "ecostress_us_men",
@@ -1856,7 +1856,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_Low"
+      "target_type": "SIF_Low (Ecostress)"
     },
     {
       "target_id": "ecostress_us_mms",
@@ -1878,7 +1878,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_Low"
+      "target_type": "SIF_Low (Ecostress)"
     },
     {
       "target_id": "ecostress_us_mrf",
@@ -1900,7 +1900,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_Low"
+      "target_type": "SIF_Low (Ecostress)"
     },
     {
       "target_id": "ecostress_us_ro4",
@@ -1922,7 +1922,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_Low"
+      "target_type": "SIF_Low (Ecostress)"
     },
     {
       "target_id": "ecostress_us_rr",
@@ -1944,7 +1944,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_Low"
+      "target_type": "SIF_Low (Ecostress)"
     },
     {
       "target_id": "ecostress_us_scc",
@@ -1963,7 +1963,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_Low"
+      "target_type": "SIF_Low (Ecostress)"
     },
     {
       "target_id": "ecostress_us_scs",
@@ -1982,7 +1982,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_Low"
+      "target_type": "SIF_Low (Ecostress)"
     },
     {
       "target_id": "ecostress_us_ses",
@@ -2004,7 +2004,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_Low"
+      "target_type": "SIF_Low (Ecostress)"
     },
     {
       "target_id": "ecostress_us_slt",
@@ -2023,7 +2023,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_Low"
+      "target_type": "SIF_Low (Ecostress)"
     },
     {
       "target_id": "ecostress_us_sp",
@@ -2045,7 +2045,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_Low"
+      "target_type": "SIF_Low (Ecostress)"
     },
     {
       "target_id": "ecostress_us_syv",
@@ -2064,7 +2064,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_Low"
+      "target_type": "SIF_Low (Ecostress)"
     },
     {
       "target_id": "ecostress_us_tx2",
@@ -2086,7 +2086,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_Low"
+      "target_type": "SIF_Low (Ecostress)"
     },
     {
       "target_id": "ecostress_us_tx5",
@@ -2108,7 +2108,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_Low"
+      "target_type": "SIF_Low (Ecostress)"
     },
     {
       "target_id": "ecostress_us_tx6",
@@ -2130,7 +2130,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_Low"
+      "target_type": "SIF_Low (Ecostress)"
     },
     {
       "target_id": "ecostress_us_tx9",
@@ -2152,7 +2152,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_Low"
+      "target_type": "SIF_Low (Ecostress)"
     },
     {
       "target_id": "ecostress_us_var",
@@ -2174,7 +2174,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_Low"
+      "target_type": "SIF_Low (Ecostress)"
     },
     {
       "target_id": "ecostress_us_vcm",
@@ -2196,7 +2196,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_Low"
+      "target_type": "SIF_Low (Ecostress)"
     },
     {
       "target_id": "ecostress_us_wjs",
@@ -2218,7 +2218,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_Low"
+      "target_type": "SIF_Low (Ecostress)"
     },
     {
       "target_id": "ecostress_us_wkg",
@@ -2240,7 +2240,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_Low"
+      "target_type": "SIF_Low (Ecostress)"
     },
     {
       "target_id": "ecostress_us_wpp",
@@ -2262,7 +2262,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_Low"
+      "target_type": "SIF_Low (Ecostress)"
     },
     {
       "target_id": "ecostress_us_wwt",
@@ -2284,7 +2284,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_Low"
+      "target_type": "SIF_Low (Ecostress)"
     },
     {
       "target_id": "fossil0001",
@@ -7436,7 +7436,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_High"
+      "target_type": "SIF_High (SIF)"
     },
     {
       "target_id": "sif_atto_2",
@@ -7458,7 +7458,7 @@
         ]
       },
       "target_altitude": null,
-      "target_type": "SIF_High"
+      "target_type": "SIF_High (SIF)"
     },
     {
       "target_id": "sif_barro_colorado",
@@ -7477,7 +7477,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_High"
+      "target_type": "SIF_High (SIF)"
     },
     {
       "target_id": "sif_guanika",
@@ -7499,7 +7499,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_High"
+      "target_type": "SIF_High (SIF)"
     },
     {
       "target_id": "sif_hrv",
@@ -7521,7 +7521,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_High"
+      "target_type": "SIF_High (SIF)"
     },
     {
       "target_id": "sif_jro",
@@ -7543,7 +7543,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_High"
+      "target_type": "SIF_High (SIF)"
     },
     {
       "target_id": "sif_k34",
@@ -7565,7 +7565,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_High"
+      "target_type": "SIF_High (SIF)"
     },
     {
       "target_id": "sif_k67",
@@ -7584,7 +7584,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_High"
+      "target_type": "SIF_High (SIF)"
     },
     {
       "target_id": "sif_lambir",
@@ -7606,7 +7606,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_High"
+      "target_type": "SIF_High (SIF)"
     },
     {
       "target_id": "sif_laselva",
@@ -7628,7 +7628,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_High"
+      "target_type": "SIF_High (SIF)"
     },
     {
       "target_id": "sif_mead",
@@ -7647,7 +7647,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_High"
+      "target_type": "SIF_High (SIF)"
     },
     {
       "target_id": "sif_mpj",
@@ -7669,7 +7669,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_High"
+      "target_type": "SIF_High (SIF)"
     },
     {
       "target_id": "sif_mzo",
@@ -7688,7 +7688,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_High"
+      "target_type": "SIF_High (SIF)"
     },
     {
       "target_id": "sif_niwot",
@@ -7710,7 +7710,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_High"
+      "target_type": "SIF_High (SIF)"
     },
     {
       "target_id": "sif_obs",
@@ -7732,7 +7732,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_High"
+      "target_type": "SIF_High (SIF)"
     },
     {
       "target_id": "sif_oko",
@@ -7754,7 +7754,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_High"
+      "target_type": "SIF_High (SIF)"
     },
     {
       "target_id": "sif_pasoh",
@@ -7776,7 +7776,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_High"
+      "target_type": "SIF_High (SIF)"
     },
     {
       "target_id": "sif_santarita",
@@ -7795,7 +7795,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_High"
+      "target_type": "SIF_High (SIF)"
     },
     {
       "target_id": "sif_shq",
@@ -7817,7 +7817,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_High"
+      "target_type": "SIF_High (SIF)"
     },
     {
       "target_id": "sif_umb",
@@ -7839,7 +7839,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_High"
+      "target_type": "SIF_High (SIF)"
     },
     {
       "target_id": "sif_uva",
@@ -7861,7 +7861,7 @@
         ]
       },
       "target_altitude": "0",
-      "target_type": "SIF_High"
+      "target_type": "SIF_High (SIF)"
     },
     {
       "target_id": "tccon100",

--- a/src/components/map/utils/index.js
+++ b/src/components/map/utils/index.js
@@ -53,8 +53,8 @@ export const addSourceLayerToMap = (
     '&rescale=' +
     VMIN +
     '%2C' +
-    VMAX;
-  // "&nodata=-9999";
+    VMAX +
+    '&nodata=nan';
 
   map.addSource(sourceId, {
     type: 'raster',

--- a/src/components/ui/card/stacItemInfoCard.tsx
+++ b/src/components/ui/card/stacItemInfoCard.tsx
@@ -130,7 +130,7 @@ export function StacItemInfoCard({
     let lvmax = VMAX || 420;
     let lcolormap = colorMap || 'plasma';
     let lassets = assets || 'rad';
-    const thumbnailUrl: string = `${process.env.REACT_APP_RASTER_API_URL}/collections/${collection}/items/${id}/preview.png?assets=${lassets}&rescale=${lvmin}%2C${lvmax}&colormap_name=${lcolormap}`;
+    const thumbnailUrl: string = `${process.env.REACT_APP_RASTER_API_URL}/collections/${collection}/items/${id}/preview.png?assets=${lassets}&rescale=${lvmin}%2C${lvmax}&colormap_name=${lcolormap}&nodata=nan`;
     setThumbnailUrl(thumbnailUrl);
 
     let firstAssetKey = Object.keys(stacItem.assets)[0];

--- a/src/pages/dashboard/index.tsx
+++ b/src/pages/dashboard/index.tsx
@@ -78,7 +78,7 @@ export function Dashboard({
   //color map
   const [VMAX, setVMAX] = useState<number>(420);
   const [VMIN, setVMIN] = useState<number>(400);
-  const [colormap, setColormap] = useState<string>('default');
+  const [colormap, setColormap] = useState<string>('viridis');
   const [assets, setAssets] = useState<string>('xco2');
   // targets based on target type
   const [targetTypes, setTargetTypes] = useState<string[]>(['all']);
@@ -352,13 +352,13 @@ export function Dashboard({
         <div style={{ position: 'absolute', right: 10, bottom: 18 }}>
           <ConfigurableColorBar
             id='coolcolor'
-            VMAXLimit={450}
-            VMINLimit={390}
+            VMAXLimit={430}
+            VMINLimit={420}
             colorMap={colormap}
             setColorMap={setColormap}
             setVMIN={setVMIN}
             setVMAX={setVMAX}
-            unit='(ppm)'
+            unit='Parts per million (ppm)'
           />
         </div>
       )}

--- a/src/pages/dashboardContainer/helper/dataTransform.ts
+++ b/src/pages/dashboardContainer/helper/dataTransform.ts
@@ -28,7 +28,8 @@ export function dataTransformation(
   const samMissingMetaDataDict: SAMMissingMetaDataDict = {};
 
   missingSamsProperties.forEach((missingSamsProp: SAMMissingMetaData) => {
-    samMissingMetaDataDict[missingSamsProp.target_id] = missingSamsProp;
+    let target_id: string = missingSamsProp.target_id.split('_')[0];
+    samMissingMetaDataDict[target_id] = missingSamsProp;
   });
 
   const fullStacItems: STACItemSAM[] = [];

--- a/src/pages/dashboardContainer/index.tsx
+++ b/src/pages/dashboardContainer/index.tsx
@@ -48,7 +48,8 @@ export function DashboardContainer(): React.JSX.Element {
     const fetchData = async () => {
       try {
         // get all the collection items
-        const collectionItemUrl: string = `${process.env.REACT_APP_STAC_API_URL}/collections/${collectionId}/items`;
+        // const collectionItemUrl: string = `${process.env.REACT_APP_STAC_API_URL}/collections/${collectionId}/items`;
+        const collectionItemUrl: string = `${process.env.PUBLIC_URL}${collectionId}.json`; // This file is created and updated by a workflow task
         const data: STACItem[] = await fetchAllFromSTACAPI(collectionItemUrl);
         const filteredData: STACItem[] = data.filter(
           (item: STACItem) => !item.id.includes('unfiltered')

--- a/src/pages/dashboardContainer/index.tsx
+++ b/src/pages/dashboardContainer/index.tsx
@@ -49,7 +49,7 @@ export function DashboardContainer(): React.JSX.Element {
       try {
         // get all the collection items
         // const collectionItemUrl: string = `${process.env.REACT_APP_STAC_API_URL}/collections/${collectionId}/items`;
-        const collectionItemUrl: string = `${process.env.PUBLIC_URL}${collectionId}.json`; // This file is created and updated by a workflow task
+        const collectionItemUrl: string = `${process.env.PUBLIC_URL}/${collectionId}.json`; // This file is created and updated by a workflow task
         const data: STACItem[] = await fetchAllFromSTACAPI(collectionItemUrl);
         const filteredData: STACItem[] = data.filter(
           (item: STACItem) => !item.id.includes('unfiltered')


### PR DESCRIPTION
## Requirement:
The current implementation of STAC api doesnot allow parallelization to fetch the STAC items. It is because the pagination of current STAC API implementation needs the next and limit. Here, next dependent on its previous response.
Hence, to speed up the process of collecting the STAC items for OCO3 collection,
we have created a workflow task. This runs before deployment (both preview and non-preview)
It is also triggered on some frequency (monthly) to update the data.

## Changes:
- Add dataCaching.js script that downloads all the STAC Items necessary for OCO3 collection and creates a json inside ./public/oco3-co2-sams-daygrid-v11r.json
- The json is bundled and exported along with the application during preview and deploy.
- The application fetched the collection data from the ./public/oco3-co2-sams-daygrid-v11r.json instead of fetching collection via the STAC endpont.
- The dataCaching.js task runs every month to update the data directly to s3.  
