### PR TITLE
fix: requested changes on oco3 data 

### DIFF
--- a/src/dataModel/sams.ts
+++ b/src/dataModel/sams.ts
@@ -141,7 +141,11 @@ export class SamsTarget implements Target {
     if (!this.isSamSorted) {
       this.inplaceSort(this.sams);
     }
-    return this.sams[0];
+    let repSam: SAM = this.sams[0];
+    repSam.geometry.coordinates = [
+      [repSam.properties.target_location.coordinates],
+    ];
+    return repSam;
   }
 
   addSAM(sam: SAM): void {

--- a/src/dataModel/sams.ts
+++ b/src/dataModel/sams.ts
@@ -10,6 +10,8 @@ import {
 } from './core';
 import moment from 'moment';
 
+import { getTargetIdFromStacIdSAM } from '../pages/dashboardContainer/helper';
+
 // TODO: change the properties to camelCase for consistency.
 // Its left at it is as the incoming data is snakecase.
 export interface SAMMissingMetaData {
@@ -39,7 +41,7 @@ export interface STACItemSAM extends STACItem {
 export interface SAM extends STACItemSAM {
   // id: is in Format: <data-type>_<target_id>_<datetime>_<filter-status>_<ghg-type>. e.g. "oco3-co2_volcano0010_2025-03-30T232216Z_unfiltered_xco2"
   // however, the <target_id> can sometimes have _ separator. Hence, index 1 doesnot always represent the full target_id
-  // solution: lets work with the semi_target_id always, i.e. target_id will be always target_id_old.split('_')[0]
+  // solution: the target_id on the metadata is correct. we just need a mechanism to find out the correct target_id from the stac_item_id
   getTargetId: () => string;
 }
 
@@ -81,7 +83,7 @@ export class SAMImpl implements SAM {
      * id: is in Format: <data-type>_<target_id>_<datetime>_<filter-status>_<ghg-type>. e.g. "oco3-co2_volcano0010_2025-03-30T232216Z_unfiltered_xco2"
      */
     if (!this.id) return '';
-    return this.id.split('_')[1];
+    return getTargetIdFromStacIdSAM(this.id);
   };
 }
 
@@ -132,7 +134,7 @@ export class SamsTarget implements Target {
      * check. SAM defination.
      */
     if (!this.id) return '';
-    return this.id.split('_')[0];
+    return this.id;
   }
 
   getRepresentationalSAM(): SAM {

--- a/src/oco3DataFactory/index.ts
+++ b/src/oco3DataFactory/index.ts
@@ -3,6 +3,8 @@ import { VizItem, SAM, Target, Lon, Lat } from '../dataModel';
 
 import { SAMImpl, SamsTarget } from '../dataModel/sams';
 
+import { getTargetIdFromStacIdSAM } from '../pages/dashboardContainer/helper';
+
 export class Oco3DataFactory extends DataFactory {
   private static instance: Oco3DataFactory;
   private constructor() {
@@ -84,7 +86,7 @@ export class Oco3DataFactory extends DataFactory {
 
   getTargetIdFromStacIdSAM = (stacItemId: string): string => {
     // check the SAM defination for explanation.
-    return stacItemId.split('_')[1];
+    return getTargetIdFromStacIdSAM(stacItemId);
   };
 
   sortAllSams(): void {

--- a/src/pages/dashboardContainer/helper/dataTransform.ts
+++ b/src/pages/dashboardContainer/helper/dataTransform.ts
@@ -19,7 +19,7 @@ export function dataTransformation(
   const samMissingMetaDataDict: SAMMissingMetaDataDict = {};
 
   missingSamsProperties.forEach((missingSamsProp: SAMMissingMetaData) => {
-    let target_id: string = missingSamsProp.target_id.split('_')[0];
+    let target_id: string = missingSamsProp.target_id;
     samMissingMetaDataDict[target_id] = missingSamsProp;
   });
 

--- a/src/pages/dashboardContainer/helper/dataTransform.ts
+++ b/src/pages/dashboardContainer/helper/dataTransform.ts
@@ -29,8 +29,12 @@ export function dataTransformation(
     const stacItemId = item.id;
     const targetId = getTargetIdFromStacIdSAM(stacItemId);
 
-    if (!(targetId in samMissingMetaDataDict)) {
+    if (
+      !(targetId in samMissingMetaDataDict) ||
+      item.id.slice(0, 7) === 'oco3-sif'
+    ) {
       // if missing properties are not available for target_id, we ignore whole SamSTACItem.
+      // also as per the discussion with JPL team, we reject all the items where the id starts with oco3-sif
       return;
     }
 

--- a/src/pages/dashboardContainer/helper/dataTransform.ts
+++ b/src/pages/dashboardContainer/helper/dataTransform.ts
@@ -31,7 +31,7 @@ export function dataTransformation(
 
     if (
       !(targetId in samMissingMetaDataDict) ||
-      item.id.slice(0, 7) === 'oco3-sif'
+      item.id.slice(0, 8) === 'oco3-sif'
     ) {
       // if missing properties are not available for target_id, we ignore whole SamSTACItem.
       // also as per the discussion with JPL team, we reject all the items where the id starts with oco3-sif

--- a/src/pages/dashboardContainer/helper/index.ts
+++ b/src/pages/dashboardContainer/helper/index.ts
@@ -3,9 +3,23 @@ export const getTargetIdFromStacIdSAM = (stacItemId: string): string => {
    * Extracts the target ID from a STAC item ID, assuming a specific naming convention used by the SAMs dataset.
    * The STAC item ID is expected to follow a pattern where the target ID is embedded within it, separated by an underscore.
    *
+   * Note: stacItemId: is in Format: <data-type>_<target_id>_<datetime>_<filter-status>_<ghg-type>. e.g. "oco3-co2_volcano0010_2025-03-30T232216Z_unfiltered_xco2"
+   * however, the <target_id> can sometimes have _ separator. Hence, index 1 doesnot always represent the full target_id
+   * solution: the target_id on the metadata is correct. we just need a mechanism to find out the correct target_id from the stac_item_id
+   *
    * @param {string} stacItemId - The STAC item ID string.
    * @returns {string} The extracted target ID for SAMs.
    */
-  let targetId: string = stacItemId.split('_')[1];
+
+  // <data-type>_<target_id>_<datetime>_<filter-status>_<ghg-type>
+  let splittedStacItemId: string[] = stacItemId.split('_');
+  // remove the first one.
+  splittedStacItemId = splittedStacItemId.slice(1, splittedStacItemId.length);
+  // remove hte last three.
+  splittedStacItemId = splittedStacItemId.slice(
+    0,
+    splittedStacItemId.length - 3
+  );
+  let targetId: string = splittedStacItemId.join('_');
   return targetId;
 };


### PR DESCRIPTION
## Requirement:
From the discussion with folks from JPL, we need to remove the stac items that starts with oco3-sif. Also, the additional categories SIF low and SIF high were broken because of faulty naming convention on the stac-item. Finally, the map markers were floating on with a bit offset.

## Changes:

- Filtered the stac-items where the stac-item id starts with oco3-sif.
- Changed the mechanism to extract the target-id from stac-item-id (needed to form a full/complete stac-item via mapping between incomplete stac-item and properties json). Instead of directly indexing the position, used negation to find the target_id i.e. by the process of elimination.
-  Took the location of repVizItems from properties.