### PR TITLE
fix: cicd not halting when dataCaching fails.

### DIFF
--- a/dataCaching.js
+++ b/dataCaching.js
@@ -79,8 +79,7 @@ async function fetchAllFromSTACAPI(STACApiUrl) {
   try {
     return await apiCaller(STACApiUrl);
   } catch (error) {
-    console.error('Error fetching data:', error);
-    return [];
+    throw new Error('Error fetching data:', error);
   }
 }
 


### PR DESCRIPTION
## Requirement

cicd needs to halt if the dataCaching script fails. Result of dataCaching script is crucial, so cannot proceed further without it.

## Changes

- throw error where the error is being handled gracefully, with exit code 1