### PR TITLE
fix: syncing of active and hover state between timeline and info card

### DIFF
--- a/src/components/map/itemTimeline/index.tsx
+++ b/src/components/map/itemTimeline/index.tsx
@@ -62,6 +62,11 @@ export const VizItemTimeline = ({
   const transformRef = useRef<d3.ZoomTransform>(d3.zoomIdentity);
   const containerRef = useRef<HTMLDivElement | null>(null);
 
+  const userClickedIdRef = useRef<string | null>(null);
+  const userHoveredIdRef = useRef<string | null>(null);
+  const hoveredItemIdRef = useRef<string | null>(null);
+
+
   const [infoOpen, setInfoOpen] = useState(false);
   const [dimensions, setDimensions] = useState({ width: 0, height: 50 });
 
@@ -84,9 +89,13 @@ export const VizItemTimeline = ({
   };
 
   const handleVizItemClick = (idx: number) => {
+    const item = parsedItems[idx];
+    if (!item) return;
+    userClickedIdRef.current = item.id;
     activeDateRef.current = dates[idx];
     setActiveIndex(idx);
-    onVizItemSelect(parsedItems[idx].id);
+    onVizItemSelect(item.id);
+    onVizItemHover(item.id);
     updateHighlights(
       svgRef,
       parsedItems,
@@ -202,9 +211,9 @@ export const VizItemTimeline = ({
         .attr('cy', 0)
         .attr('r', 5)
         .attr('fill', d => {
-          if (d.id === hoveredItemId) return '#9dc1fa'; // color for hovered item
-          if (d.date.getTime() === activeDateRef.current.getTime()) return '#3b82f6'; // active item color
-          return '#9ca3af'; // default gray
+          if (d.id === hoveredItemIdRef.current) return '#9dc1fa';
+          if (d.date.getTime() === activeDateRef.current.getTime()) return '#3b82f6';
+          return '#9ca3af';
         })
         .style('cursor', 'pointer')
         .on('click', (e, d) => {
@@ -212,6 +221,7 @@ export const VizItemTimeline = ({
           handleVizItemClick(idx);
         })
         .on('mouseover', function (e, d) {
+          userHoveredIdRef.current = d.id;
           const isActive = d.date.getTime() === activeDateRef.current.getTime();
           if (!isActive) d3.select(this).attr('fill', '#9dc1fa'); // muted hover color
           const idx = parsedItems.findIndex(item => item.id === d.id);
@@ -267,22 +277,57 @@ export const VizItemTimeline = ({
       setActiveIndex(0);
       activeDateRef.current = parsedItems[0]?.date;
     }
+
+    updateHighlights(
+      svgRef,
+      parsedItems,
+      activeDateRef.current,
+      baseX,
+      transformRef.current
+    );
+
+    // Only center if the change is NOT from user click
+    if (activeItemId !== userClickedIdRef.current) {
+      centerOnDate(
+        svgRef,
+        activeDateRef.current,
+        transformRef.current.k, // keep current zoom level
+        dimensions.width,
+        margin,
+        baseX!,
+        zoomRef.current!
+      );
+    }
+
+    // Reset the ref — so future updates are treated as external unless clicked again
+    userClickedIdRef.current = null;
   }, [parsedItems, activeItemId]);
 
 
   useEffect(() => {
+    if (!svgRef.current) return;
     const svg = d3.select(svgRef.current);
     const g = svg.select('g');
     if (!g || !parsedItems.length) return;
 
-    // Re-select circles and re-bind data
-    const circles = g.selectAll<SVGCircleElement, STACItem>('circle').data(parsedItems);
+    hoveredItemIdRef.current = hoveredItemId;
 
-    circles.attr('fill', d => {
-      if (d.id === hoveredItemId) return '#9dc1fa'; // hovered
-      if (d.date.getTime() === activeDateRef.current.getTime()) return '#3b82f6'; // active
-      return '#9ca3af'; // default
-    });
+    if (hoveredItemId !== userHoveredIdRef.current) {
+      const hoveredItem = parsedItems.find(item => item.id === hoveredItemId);
+      if (hoveredItem) {
+        centerOnDate(
+          svgRef,
+          hoveredItem.date,
+          transformRef.current.k,
+          dimensions.width,
+          margin,
+          baseX!,
+          zoomRef.current!
+        );
+      }
+    }
+    userHoveredIdRef.current = null; // reset after handling hover
+
   }, [hoveredItemId]);
 
 

--- a/src/pages/dashboard/index.tsx
+++ b/src/pages/dashboard/index.tsx
@@ -58,6 +58,7 @@ export function Dashboard({
   // states for data
   const [targets, setTargets] = useState<VizItem[]>([]);
   const [hoveredVizLayerId, setHoveredVizLayerId] = useState<string>(''); // vizItem_id of the visualization item which was hovered over
+  const [activeVizLayerId, setActiveVizLayerId] = useState<string>(''); // vizItem_id of the visualization item which was clicked on
   const [filteredVizItems, setFilteredVizItems] = useState<VizItem[]>([]); // visualization items for the selected region with the filter applied
   const [visualizationLayers, setVisualizationLayers] = useState<VizItem[]>([]); //all visualization items for the selected region (marker) // TODO: make it take just one instead of a list.
   const [selectedSams, setSelectedSams] = useState<VizItem[]>([]); // this represents the sams, when a target is selected.
@@ -101,11 +102,12 @@ export function Dashboard({
     setZoomLevel(null); // take the default zoom level
     setOpenDrawer(true);
     setHoveredVizLayerId(vizItemId);
+    setActiveVizLayerId(vizItemId);
   }, []);
 
   const handleSelectedVizLayer = useCallback((vizItemId: string) => {
     if (!vizItemId) return;
-    // currently no functionality needed.
+    setActiveVizLayerId(vizItemId);
   }, []);
 
   const handleResetHome = useCallback(() => {
@@ -117,6 +119,7 @@ export function Dashboard({
     setSelectedSams([]);
     setFilteredVizItems(repTargets);
     setHoveredVizLayerId('');
+    setActiveVizLayerId('');
     setOpenDrawer(false);
     setZoomLevel(4);
     setZoomLocation([-98.771556, 32.967243]);
@@ -144,6 +147,7 @@ export function Dashboard({
       dataFactory.current?.getVizItemByVizId(vizItemId);
     if (changedVizItem) setVisualizationLayers([changedVizItem]);
     setHoveredVizLayerId(vizItemId);
+    setActiveVizLayerId(vizItemId);
   }, []);
 
   const handleHoverOverSelectedSams = useCallback((vizItemId: string) => {
@@ -219,16 +223,14 @@ export function Dashboard({
             <div className='title-content'>
               {selectedSams.length ? (
                 <HorizontalLayout>
-                  {/* <div className={"sandesh"} style={{ margin: '0 0.9rem' }}> */}
                   <VizItemTimeline
                     vizItems={selectedSams}
                     onVizItemSelect={handleTimelineTimeChange}
-                    activeItemId={hoveredVizLayerId}
+                    activeItemId={activeVizLayerId}
                     onVizItemHover={handleHoverOverSelectedSams}
                     hoveredItemId={hoveredVizLayerId}
                     title='Timeline'
                   />
-                  {/* </div> */}
                 </HorizontalLayout>
               ) : (
                 <></>


### PR DESCRIPTION
Requirement
--
Active and hover state properly sync between timeline and info card

Changes
--
1. Pass activeItemId and hoverItemId from dashboard to timeline
2. Keep track of points hovered and clicked by user (userClickedIdRef and userHoveredIdRef) so that timeline doesn't move when user hover over and click item with pointer
3. Center on hovered item and active item if the state is changed by timeline control buttons or by info card

