### PR TITLE
feat: update colormap slider to allow for range beyond what is provided as the limit

### DIFF
--- a/src/components/ui/configurableColorBar/colormapOptions.jsx
+++ b/src/components/ui/configurableColorBar/colormapOptions.jsx
@@ -18,7 +18,7 @@ import IconButton from '@mui/material/IconButton';
 
 import './index.css';
 
-/**
+/*
  * ColormapOptions component for configuring parameters of configurable color bar.
  *
  * @param {number} localVMin - Current committed minimum value for the visualization range.

--- a/src/components/ui/configurableColorBar/colormapOptions.jsx
+++ b/src/components/ui/configurableColorBar/colormapOptions.jsx
@@ -187,9 +187,11 @@ export const ColormapOptions = ({
             />
           </Box>
           <Box>
-            <IconButton size="small" onClick={handleReset}>
-              <ResetIcon fontSize="small" />
-            </IconButton>
+            <Tooltip title="Reset to default values">
+              <IconButton size="small" onClick={handleReset}>
+                <ResetIcon fontSize="small" />
+              </IconButton>
+            </Tooltip>
           </Box>
         </Box>
       </Box>

--- a/src/components/ui/configurableColorBar/colormapOptions.jsx
+++ b/src/components/ui/configurableColorBar/colormapOptions.jsx
@@ -18,7 +18,7 @@ import IconButton from '@mui/material/IconButton';
 
 import './index.css';
 
-/*
+/**
  * ColormapOptions component for configuring parameters of configurable color bar.
  *
  * @param {number} localVMin - Current committed minimum value for the visualization range.

--- a/src/components/ui/configurableColorBar/colormapOptions.jsx
+++ b/src/components/ui/configurableColorBar/colormapOptions.jsx
@@ -18,33 +18,46 @@ import IconButton from '@mui/material/IconButton';
 
 import './index.css';
 
+/**
+ * ColormapOptions component for configuring parameters of configurable color bar.
+ *
+ * @param {number} localVMin - Current committed minimum value for the visualization range.
+ * @param {number} localVMax - Current committed maximum value for the visualization range.
+ * @param {number} minLimit  - Absolute minimum limit allowed for the slider/input.
+ * @param {number} maxLimit  - Absolute maximum limit allowed for the slider/input.
+ * @param {string} colorMap  - Current colormap name (e.g., 'viridis', 'turbo', optionally with '_r' for reverse).
+ * @param {function} setLocalVMAX - Callback to update the committed maximum value in the parent component.
+ * @param {function} setLocalVMIN - Callback to update the committed minimum value in the parent component.
+ * @param {function} setSelColorMap - Callback to update the selected colormap in the parent component.
+ * @param {function} setIsReverse   - Callback to toggle reverse mode in the parent component.
+ */
 export const ColormapOptions = ({
-  currentMin,
-  currentMax,
+  localVMin,
+  localVMax,
   minLimit,
   maxLimit,
   colorMap,
-  setCurrVMAX,
-  setCurrVMIN,
+  setLocalVMAX,
+  setLocalVMIN,
   setSelColorMap,
   setIsReverse,
 }) => {
 
   // committed values (drive UI & outputs)
-  const [minValue, setMinValue] = useState(currentMin);
-  const [maxValue, setMaxValue] = useState(currentMax);
+  const [minValue, setMinValue] = useState(localVMin);
+  const [maxValue, setMaxValue] = useState(localVMax);
 
   // editable text inputs (don’t validate while typing)
-  const [minInput, setMinInput] = useState(String(currentMin));
-  const [maxInput, setMaxInput] = useState(String(currentMax));
+  const [minInput, setMinInput] = useState(String(localVMin));
+  const [maxInput, setMaxInput] = useState(String(localVMax));
 
   // slider display values during drag (don’t commit until mouseup)
   const [sliderVals, setSliderVals] = useState([minLimit, maxLimit]);
 
   // slider range is stable while dragging; expands only on commit
   const [range, setRange] = useState([
-    Math.min(minLimit, currentMin),
-    Math.max(maxLimit, currentMax),
+    Math.min(minLimit, localVMin),
+    Math.max(maxLimit, localVMax),
   ]);
 
   const [reverse, setReverse] = useState(false);
@@ -55,16 +68,16 @@ export const ColormapOptions = ({
 
   // sync when parent updates current range
   useEffect(() => {
-    setMinValue(currentMin);
-    setMaxValue(currentMax);
-    setMinInput(String(currentMin));
-    setMaxInput(String(currentMax));
-    setSliderVals([currentMin, currentMax]);
+    setMinValue(localVMin);
+    setMaxValue(localVMax);
+    setMinInput(String(localVMin));
+    setMaxInput(String(localVMax));
+    setSliderVals([localVMin, localVMax]);
     setRange((r) => ([
-      Math.min(minLimit, r[0], currentMin),
-      Math.max(maxLimit, r[1], currentMax),
+      Math.min(minLimit, r[0], localVMin),
+      Math.max(maxLimit, r[1], localVMax),
     ]));
-  }, [currentMin, currentMax, minLimit, maxLimit]);
+  }, [localVMin, localVMax, minLimit, maxLimit]);
 
   // Text inputs for slider range (validate on blur / Enter)
   const handleMinChange = (e) => {
@@ -91,7 +104,7 @@ export const ColormapOptions = ({
     setSliderVals(([_, r]) => [v, r]);
     // expand range only if needed
     setRange(([lo, hi]) => [Math.min(lo, v, minLimit), Math.max(hi, maxValue)]);
-    setCurrVMIN?.(v);
+    setLocalVMIN?.(v);
   };
 
   const commitMax = () => {
@@ -108,7 +121,7 @@ export const ColormapOptions = ({
     setMaxValue(v);
     setSliderVals(([l, _]) => [l, v]);
     setRange(([lo, hi]) => [Math.min(lo, minValue), Math.max(hi, v, maxLimit)]);
-    setCurrVMAX?.(v);
+    setLocalVMAX?.(v);
   };
 
   const onKeyDownCommit = (e, which) => {
@@ -133,8 +146,8 @@ export const ColormapOptions = ({
     if (l === r) return;
     setMinValue(l);
     setMaxValue(r);
-    setCurrVMIN?.(l);
-    setCurrVMAX?.(r);
+    setLocalVMIN?.(l);
+    setLocalVMAX?.(r);
     // Keep the displayed range stable; only expand if out-of-bounds
     setRange(([lo, hi]) => [Math.min(lo, l), Math.max(hi, r)]);
   };
@@ -155,11 +168,11 @@ export const ColormapOptions = ({
   const handleReset = () => {
     setMinValue(minLimit);
     setMinInput(String(minLimit));
-    setCurrVMIN(minLimit);
+    setLocalVMIN(minLimit);
 
     setMaxValue(maxLimit);
     setMaxInput(String(maxLimit));
-    setCurrVMAX(maxLimit);
+    setLocalVMAX(maxLimit);
 
     setSliderVals([minLimit, maxLimit]);
     setRange([minLimit, maxLimit]);

--- a/src/components/ui/configurableColorBar/index.jsx
+++ b/src/components/ui/configurableColorBar/index.jsx
@@ -16,7 +16,7 @@ import { ColorBar } from '../colorBar';
 
 import './index.css';
 
-/**
+/*
  * ConfigurableColorBar component for displaying and customizing a color scale.
  * Includes controls for adjusting the range (VMIN/VMAX), selecting a colormap,
  * and toggling reverse mode.

--- a/src/components/ui/configurableColorBar/index.jsx
+++ b/src/components/ui/configurableColorBar/index.jsx
@@ -13,7 +13,6 @@ import CloseIcon from '@mui/icons-material/Close';
 
 import { ColormapOptions } from './colormapOptions';
 import { ColorBar } from '../colorBar';
-import { Padding } from "@mui/icons-material";
 
 import './index.css';
 
@@ -82,8 +81,10 @@ export const ConfigurableColorBar = ({
       </AccordionSummary>
       <AccordionDetails className="configurable-colorbar-details">
         <ColormapOptions
-          VMIN={VMINLimit}
-          VMAX={VMAXLimit}
+          currentMin={currVMIN}
+          currentMax={currVMAX}
+          minLimit={VMINLimit}
+          maxLimit={VMAXLimit}
           colorMap={colorMap}
           setCurrVMAX={setCurrVMAX}
           setCurrVMIN={setCurrVMIN}

--- a/src/components/ui/configurableColorBar/index.jsx
+++ b/src/components/ui/configurableColorBar/index.jsx
@@ -16,24 +16,38 @@ import { ColorBar } from '../colorBar';
 
 import './index.css';
 
+/**
+ * ConfigurableColorBar component for displaying and customizing a color scale.
+ * Includes controls for adjusting the range (VMIN/VMAX), selecting a colormap,
+ * and toggling reverse mode.
+ *
+ * @param {string} id - Unique identifier for this color bar instance.
+ * @param {number} VMINLimit - Absolute minimum value allowed for the color scale.
+ * @param {number} VMAXLimit - Absolute maximum value allowed for the color scale.
+ * @param {string} colorMap - Initial colormap name (e.g., 'magma', 'viridis', 'turbo', optionally with '_r' for reverse).
+ * @param {function} setVMIN - Callback to update the committed minimum value in the parent component.
+ * @param {function} setVMAX - Callback to update the committed maximum value in the parent component.
+ * @param {function} setColorMap - Callback to update the colormap in the parent component.
+ * @param {string} [unit=''] - Optional unit label displayed under the color bar.
+ */
 export const ConfigurableColorBar = ({ 
     id,
-    VMINLimit, 
-    VMAXLimit, 
-    colorMap, 
-    setVMIN, 
-    setVMAX, 
+    VMINLimit,
+    VMAXLimit,
+    colorMap,
+    setVMIN,
+    setVMAX,
     setColorMap,
     unit='',
   }) => {
-  const [currVMIN, setCurrVMIN] = useState(VMINLimit);
-  const [currVMAX, setCurrVMAX] = useState(VMAXLimit);
+  const [localVMIN, setLocalVMIN] = useState(VMINLimit);
+  const [localVMAX, setLocalVMAX] = useState(VMAXLimit);
+
   const [currColorMap, setCurrColorMap] = useState(colorMap);
-  const [isReversed, setIsReverse] = useState(false);
   const [selColorMap, setSelColorMap] = useState(colorMap);
+  const [isReversed, setIsReverse] = useState(false);
 
   const [expanded, setExpanded] = useState(false);
-
 
   useEffect(() => {
     // key == dataProduct
@@ -42,10 +56,10 @@ export const ConfigurableColorBar = ({
     if (isReversed) colorMap += "_r";
     setCurrColorMap(colorMap);
     setColorMap(colorMap);
-    setVMIN(currVMIN);
-    setVMAX(currVMAX);
+    setVMIN(localVMIN);
+    setVMAX(localVMAX);
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currVMIN, currVMAX, selColorMap, isReversed])
+  }, [localVMIN, localVMAX, selColorMap, isReversed])
 
   return (
     <Accordion
@@ -67,10 +81,10 @@ export const ConfigurableColorBar = ({
           </div>
           
           <ColorBar
-            VMIN={currVMIN}
-            VMAX={currVMAX}
+            VMIN={localVMIN}
+            VMAX={localVMAX}
             colorMap={currColorMap}
-            STEP={(currVMAX-currVMIN)/5}
+            STEP={(localVMAX-localVMIN)/5}
           />
           
           { unit && <div style={{ textAlign: 'center'}}>
@@ -81,13 +95,13 @@ export const ConfigurableColorBar = ({
       </AccordionSummary>
       <AccordionDetails className="configurable-colorbar-details">
         <ColormapOptions
-          currentMin={currVMIN}
-          currentMax={currVMAX}
+          localVMin={localVMIN}
+          localVMax={localVMAX}
           minLimit={VMINLimit}
           maxLimit={VMAXLimit}
           colorMap={colorMap}
-          setCurrVMAX={setCurrVMAX}
-          setCurrVMIN={setCurrVMIN}
+          setLocalVMAX={setLocalVMAX}
+          setLocalVMIN={setLocalVMIN}
           setSelColorMap={setSelColorMap}
           setIsReverse={setIsReverse}
         />

--- a/src/components/ui/configurableColorBar/index.jsx
+++ b/src/components/ui/configurableColorBar/index.jsx
@@ -16,19 +16,24 @@ import { ColorBar } from '../colorBar';
 
 import './index.css';
 
-/*
+/**
+ * @typedef {Object} ConfigurableColorBarProps
+ * @property {string} id - Unique identifier for this color bar instance.
+ * @property {number} VMINLimit - Absolute minimum value allowed for the color scale.
+ * @property {number} VMAXLimit - Absolute maximum value allowed for the color scale.
+ * @property {string} colorMap - Initial colormap name (e.g., 'magma', 'viridis').
+ * @property {(v: number) => void} setVMIN - Callback to update the committed minimum value.
+ * @property {(v: number) => void} setVMAX - Callback to update the committed maximum value.
+ * @property {(v: string) => void} setColorMap - Callback to update the colormap.
+ * @property {string} [unit] - Optional unit label displayed under the color bar.
+ */
+
+/**
  * ConfigurableColorBar component for displaying and customizing a color scale.
  * Includes controls for adjusting the range (VMIN/VMAX), selecting a colormap,
  * and toggling reverse mode.
- *
- * @param {string} id - Unique identifier for this color bar instance.
- * @param {number} VMINLimit - Absolute minimum value allowed for the color scale.
- * @param {number} VMAXLimit - Absolute maximum value allowed for the color scale.
- * @param {string} colorMap - Initial colormap name (e.g., 'magma', 'viridis', 'turbo', optionally with '_r' for reverse).
- * @param {function} setVMIN - Callback to update the committed minimum value in the parent component.
- * @param {function} setVMAX - Callback to update the committed maximum value in the parent component.
- * @param {function} setColorMap - Callback to update the colormap in the parent component.
- * @param {string} [unit=''] - Optional unit label displayed under the color bar.
+ * 
+ * @param {ConfigurableColorBarProps} props
  */
 export const ConfigurableColorBar = ({ 
     id,

--- a/src/pages/dashboard/index.tsx
+++ b/src/pages/dashboard/index.tsx
@@ -55,6 +55,11 @@ export function Dashboard({
   setZoomLevel,
   loadingData,
 }: DashboardProps) {
+  // default values
+  const DEFAULT_COLOR_MAP = 'magma'; // default color map for the visualization layers
+  const DEFAULT_VMIN = 400; // default minimum value for the color bar
+  const DEFAULT_VMAX = 420; // default maximum value for the color bar
+
   // states for data
   const [targets, setTargets] = useState<VizItem[]>([]);
   const [hoveredVizLayerId, setHoveredVizLayerId] = useState<string>(''); // vizItem_id of the visualization item which was hovered over
@@ -63,9 +68,9 @@ export function Dashboard({
   const [visualizationLayers, setVisualizationLayers] = useState<VizItem[]>([]); //all visualization items for the selected region (marker) // TODO: make it take just one instead of a list.
   const [selectedSams, setSelectedSams] = useState<VizItem[]>([]); // this represents the sams, when a target is selected.
   //color map
-  const [VMAX, setVMAX] = useState<number>(420);
-  const [VMIN, setVMIN] = useState<number>(400);
-  const [colormap, setColormap] = useState<string>('magma');
+  const [VMAX, setVMAX] = useState<number>(DEFAULT_VMAX);
+  const [VMIN, setVMIN] = useState<number>(DEFAULT_VMIN);
+  const [colormap, setColormap] = useState<string>(DEFAULT_COLOR_MAP);
   const [assets, setAssets] = useState<string>('xco2');
   // targets based on target type
   const [targetTypes, setTargetTypes] = useState<string[]>([]);
@@ -160,9 +165,9 @@ export function Dashboard({
     setTargetTypes([...targetTypesLocal]);
 
     // also few extra things for the application state. We can receive it from collection json.
-    const VMIN = 400;
-    const VMAX = 420;
-    const colormap: string = 'magma';
+    const VMIN = DEFAULT_VMIN;
+    const VMAX = DEFAULT_VMAX;
+    const colormap: string = DEFAULT_COLOR_MAP;
     setVMIN(VMIN);
     setVMAX(VMAX);
     setColormap(colormap);
@@ -244,9 +249,9 @@ export function Dashboard({
             {VMAX && (
               <ConfigurableColorBar
                 id='configurable-color-bar'
-                VMAXLimit={420}
-                VMINLimit={400}
-                colorMap={colormap}
+                VMAXLimit={DEFAULT_VMAX}
+                VMINLimit={DEFAULT_VMIN}
+                colorMap={DEFAULT_COLOR_MAP}
                 setColorMap={setColormap}
                 setVMIN={setVMIN}
                 setVMAX={setVMAX}

--- a/src/pages/dashboard/index.tsx
+++ b/src/pages/dashboard/index.tsx
@@ -248,14 +248,14 @@ export function Dashboard({
             )}
             {VMAX && (
               <ConfigurableColorBar
-                id='configurable-color-bar'
+                id={'configurable-color-bar'}
                 VMAXLimit={DEFAULT_VMAX}
                 VMINLimit={DEFAULT_VMIN}
                 colorMap={DEFAULT_COLOR_MAP}
                 setColorMap={setColormap}
                 setVMIN={setVMIN}
                 setVMAX={setVMAX}
-                unit='parts per million (ppm)'
+                unit={'parts per million (ppm)'}
               />
             )}
           </div>


### PR DESCRIPTION
Requirements
--
Users are able to change the rescale value of the color map beyond the limit set by the dashboard and safely reset to default value

Changes
--
1. Text input of colormap rescale option takes value beyond min and max limit
2. Range of slider auto expands according to the user input. It selects minimum/maximum of user provided rescale value, current rescale value and global VMIN/VMAX limit for minimum/maximum range
3. The min/max input on textbox are validated and applied only on blur or Enter (no blocking while typing)
4. Reset button restores scale, reverse flag, and colormap to the original defaults