### PR TITLE
fix: OCO3 description typo and issue where changing basemap clears the visualization layer

### DIFF
--- a/src/components/map/mapControls/index.jsx
+++ b/src/components/map/mapControls/index.jsx
@@ -191,7 +191,51 @@ export const MapControls = ({
     mapboxgl.accessToken = mapboxAccessToken;
 
     if (map) {
+      // Store current layers and sources before changing style
+      const customLayers = [];
+      const customSources = {};
+
+      // Get all layers that are not part of the basemap
+      const style = map.getStyle();
+      if (style && style.layers) {
+        style.layers.forEach((layer) => {
+          // Check if this is a custom layer (not part of the basemap)
+          if (layer.id.includes('raster') || layer.id.includes('polygon')) {
+            customLayers.push({
+              layer: layer,
+              before: null // We'll add it on top
+            });
+
+            // Store the source data
+            if (layer.source && !customSources[layer.source]) {
+              const source = map.getSource(layer.source);
+              if (source) {
+                customSources[layer.source] = source.serialize();
+              }
+            }
+          }
+        });
+      }
+
+      // Change the basemap style
       map.setStyle(mapboxStyleBaseUrl);
+
+      // Re-add custom layers after the style has loaded
+      map.once('style.load', () => {
+        // Re-add sources
+        Object.entries(customSources).forEach(([sourceId, sourceData]) => {
+          if (!map.getSource(sourceId)) {
+            map.addSource(sourceId, sourceData);
+          }
+        });
+
+        // Re-add layers
+        customLayers.forEach(({ layer }) => {
+          if (!map.getLayer(layer.id)) {
+            map.addLayer(layer);
+          }
+        });
+      });
     }
   };
 

--- a/src/pages/dashboard/index.tsx
+++ b/src/pages/dashboard/index.tsx
@@ -29,7 +29,7 @@ import { Oco3DataFactory } from '../../oco3DataFactory';
 import './index.css';
 
 const TITLE: string = 'OCO-3 Carbon Dioxide Snapshot Area Maps';
-const DESCRIPTION: string = `The Orbiting Carbon Observatory 3 (OCO-3)’s Snapshot Area Mapping (SAM) mode allows OCO-3 to quickly scan large areas (80 km x 80 km) and collect data over specific targets, like urban areas, megacities, and volcanoes, from the vantage point of the International Space Station (ISS). Shown here are SAMs of atmospheric CO2. <a href="https://earth.gov/ghgcenter/data-catalog/oco3-co2-sams-daygrid-v11r" target="_blank" rel="noreferrer">Click here for more details.</a>.`;
+const DESCRIPTION: string = `The Orbiting Carbon Observatory 3 (OCO-3)’s Snapshot Area Mapping (SAM) mode allows OCO-3 to quickly scan large areas (80 km x 80 km) and collect data over specific targets, like urban areas, megacities, and volcanoes, from the vantage point of the International Space Station (ISS). Shown here are SAMs of atmospheric CO₂. <a href="https://earth.gov/ghgcenter/data-catalog/oco3-co2-sams-daygrid-v11r" target="_blank" rel="noreferrer">Click here for more details.</a>`;
 
 const HorizontalLayout = styled.div`
   width: 90%;


### PR DESCRIPTION
Changes
--
1. Fix typo in the description text
2. Store layers and sources before changing basemap and add it afterwards