### PR TITLE
fix: Add check for candidate SAMs before setting visualization layers

### DIFF
--- a/dataCaching.js
+++ b/dataCaching.js
@@ -90,6 +90,8 @@ async function fetchAllFromSTACAPI(STACApiUrl) {
  * @returns {Promise<any>} A promise that resolves to the list of items fetched from the API.
  */
 async function apiCaller(STACApiUrl) {
+  // limit per fetch
+  const urlFetchLimit = 1000;
   let requiredResult = [];
 
   if (!STACApiUrl) return requiredResult;
@@ -97,10 +99,10 @@ async function apiCaller(STACApiUrl) {
   let urlWithLimit = STACApiUrl;
 
   if (!STACApiUrl.includes('limit') && STACApiUrl.includes('token')) {
-    urlWithLimit = `${STACApiUrl}&limit=10000`;
+    urlWithLimit = `${STACApiUrl}&limit=${urlFetchLimit}`;
   }
   if (!STACApiUrl.includes('limit') && !STACApiUrl.includes('token')) {
-    urlWithLimit = `${STACApiUrl}?limit=10000`;
+    urlWithLimit = `${STACApiUrl}?limit=${urlFetchLimit}`;
   }
 
   console.log('## fetching from --> ', urlWithLimit);

--- a/src/pages/dashboard/index.tsx
+++ b/src/pages/dashboard/index.tsx
@@ -93,10 +93,14 @@ export function Dashboard({
     const vizItemId = (typeof vizItem !== 'string') ? vizItem.id : vizItem;
 
     if (!vizItemId || !dataFactory.current) return;
+    
     let targetId: string =
       dataFactory.current?.getTargetIdFromStacIdSAM(vizItemId);
     let candidateSams: SAM[] =
       dataFactory.current?.getVizItemsOnMarkerClicked(targetId) || [];
+
+    // if no sams found, return.
+    if (candidateSams.length === 0) return;
 
     let placeHolderSam: SAM = candidateSams[0];
     setVisualizationLayers([placeHolderSam]);


### PR DESCRIPTION
**Requirements**
Searching by SAM name and hitting ENTER (rather than selecting from dropdown) breaks the tool

**Changes**
Add check for candidate SAMs before setting visualization layers